### PR TITLE
Fix duplicate function declarations (Issue #32)

### DIFF
--- a/internal/domain/models/converters.go
+++ b/internal/domain/models/converters.go
@@ -146,16 +146,6 @@ func ParseHTTPHeaders(headers map[string]string) []HTTPHeader {
 	return result
 }
 
-// StringToBytes converts a string to a byte slice
-func StringToBytes(s string) []byte {
-	return []byte(s)
-}
-
-// BytesToString converts a byte slice to a string
-func BytesToString(b []byte) string {
-	return string(b)
-}
-
 // ConvertHeadersToMap converts a slice of HTTPHeader to a map
 func ConvertHeadersToMap(headers []HTTPHeader) map[string]string {
 	result := make(map[string]string)


### PR DESCRIPTION
## Description

This PR fixes the duplicate function declarations that were causing build errors. After the model field compatibility fixes, there were duplicate `BytesToString` and `StringToBytes` functions in both `converters.go` and `utils.go`.

### Changes Made

1. **Removed duplicates from converters.go**:
   - Removed `BytesToString` function 
   - Removed `StringToBytes` function
   - Kept the implementation in `utils.go` since it's more comprehensive (with null checks)

2. **Clean code practices**:
   - Followed DRY principle by consolidating utility functions
   - Maintained clean architecture by keeping responsibilities clear
   - Fixed build errors without changing functionality

### Testing

The changes have been tested to ensure:
- The application builds successfully
- No functionality changes introduced
- All previous usages of these functions still work correctly

Closes #32
