### PR TITLE
Fix type inconsistencies in assertion_evaluator.go

### DIFF
--- a/internal/infrastructure/asserter/assertion_evaluator.go
+++ b/internal/infrastructure/asserter/assertion_evaluator.go
@@ -64,10 +64,10 @@ func (s *AssertionEvaluatorService) EvaluateAssertion(
 	
 	// Initialize the result
 	result := &models.TestAssertionResult{
-		Type:      assertion.Type,
-		Source:    assertion.Source,
-		Path:      assertion.Path,
-		Actual:    actualValue,
+		Type:    assertion.Type,
+		Source:  assertion.Source,
+		Path:    assertion.Path,
+		Actual:  actualValue,
 	}
 	
 	// Evaluate the assertion based on its type
@@ -141,8 +141,11 @@ func (s *AssertionEvaluatorService) EvaluateAssertion(
 	case "in":
 		// Check if the actual value is in the list of expected values
 		var found bool
+		// Create a string representation of the expected values
+		expectedValues := make([]string, 0, len(assertion.Values))
+		
 		for _, val := range assertion.Values {
-			result.Expected += val + ", "
+			expectedValues = append(expectedValues, val)
 			equals := actualValue == val
 			if assertion.IgnoreCase {
 				equals = strings.EqualFold(strings.ToLower(actualValue), strings.ToLower(val))
@@ -152,13 +155,16 @@ func (s *AssertionEvaluatorService) EvaluateAssertion(
 				break
 			}
 		}
-		result.Expected = strings.TrimSuffix(result.Expected, ", ")
+		
+		// Join the expected values for display
+		expectedStr := strings.Join(expectedValues, ", ")
+		result.Expected = expectedStr
 		result.Succeeded = (found != assertion.Not)
 		if !result.Succeeded {
 			if assertion.Not {
-				result.Message = fmt.Sprintf("Expected value to not be one of [%s]", result.Expected)
+				result.Message = fmt.Sprintf("Expected value to not be one of [%s]", expectedStr)
 			} else {
-				result.Message = fmt.Sprintf("Expected value to be one of [%s], got '%s'", result.Expected, actualValue)
+				result.Message = fmt.Sprintf("Expected value to be one of [%s], got '%s'", expectedStr, actualValue)
 			}
 		}
 		
@@ -233,7 +239,7 @@ func (s *AssertionEvaluatorService) getValueFromResponse(
 				Source: "body",
 				Path:   path,
 			}
-			return s.variableExtractor.extractFromBody(response, extraction)
+			return s.variableExtractor.ExtractFromBody(response, extraction)
 		}
 		// Return the entire body as string
 		return string(response.Body), nil

--- a/internal/infrastructure/extractor/variable_extractor.go
+++ b/internal/infrastructure/extractor/variable_extractor.go
@@ -167,7 +167,7 @@ func (s *VariableExtractorService) LoadVariables(
 func (s *VariableExtractorService) extractValue(response *models.HTTPResponse, extraction models.VariableExtraction) (string, error) {
 	switch strings.ToLower(extraction.Source) {
 	case "body":
-		return s.extractFromBody(response, extraction)
+		return s.ExtractFromBody(response, extraction)
 	case "header":
 		return s.extractFromHeader(response, extraction)
 	case "status":
@@ -177,8 +177,8 @@ func (s *VariableExtractorService) extractValue(response *models.HTTPResponse, e
 	}
 }
 
-// Extract value from response body
-func (s *VariableExtractorService) extractFromBody(response *models.HTTPResponse, extraction models.VariableExtraction) (string, error) {
+// ExtractFromBody extracts a value from the response body
+func (s *VariableExtractorService) ExtractFromBody(response *models.HTTPResponse, extraction models.VariableExtraction) (string, error) {
 	// Check if a JSON path is specified
 	if extraction.Path != "" {
 		return s.extractFromJsonPath(response.Body, extraction.Path)


### PR DESCRIPTION
## Descrição

Este PR resolve os problemas de tipos incompatíveis no arquivo `internal/infrastructure/asserter/assertion_evaluator.go`. Especificamente, foram resolvidos os seguintes erros:

1. `result.Expected += val + ", "` (tipos incompatíveis interface{} e string)
2. `strings.TrimSuffix(result.Expected, ", ")` (não pode usar interface{} como string)
3. `s.variableExtractor.extractFromBody` (não pode acessar método não exportado)

## Mudanças

1. Exportado o método `extractFromBody` para `ExtractFromBody` no pacote extractor
2. Atualizada a lógica do caso "in" para usar uma slice de strings e `strings.Join` em vez de concatenação direta
3. Corrigido o uso do resultado no formato string para trabalhar corretamente com o campo `Expected` do tipo `interface{}`

## Testes

O código agora compila sem erros e mantém a mesma funcionalidade.

Resolve #35